### PR TITLE
add custom client feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 DATABASE_URL="sqlite://db/files.db"
 SERVER_DOMAIN="http://localhost:3000"
 
+# Space-seprated list of custom features
+# Currently supported:
+# - custom_client   # Use a custom client at the root path instead of the default client
+#                   # This moves the default client and its endpoints to /legacy instead
+# - disable_default_client  # Disables the default client if you exclusively want to use a custom client
+FEATURES=""
+
 # Can be generated using
 # python3 -c "import secrets; print(secrets.token_urlsafe(64))"
 JWT_TOKEN_SECRET="random-string"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,4 +10,7 @@ lazy_static! {
         var("SERVER_DOMAIN").unwrap_or(format!("http://localhost:{}", *SERVER_PORT));
     pub static ref SERVER_NAME: String = var("SERVER_NAME").unwrap_or("Filehost".to_string());
     pub static ref ROOT_FOLDER: String = var("ROOT_FOLDER").unwrap_or("files".to_string());
+    static ref FEATURES_STRING: String = var("FEATURES").unwrap_or("".to_string());
+    pub static ref FEATURES: Vec<&'static str> =
+        FEATURES_STRING.split_whitespace().collect::<Vec<&str>>();
 }


### PR DESCRIPTION
Also add ability to disable default client
Useful if you want to use a different client from the default

Enabling `disable_default_client` would currently break uploads. Fixing that is out of scope for this PR